### PR TITLE
update deprecated hdwallet-provider

### DIFF
--- a/truffle-config.js
+++ b/truffle-config.js
@@ -36,7 +36,7 @@ const option = {
   ],
   keepAlive: false,
 }
-const HDWalletProvider = require("truffle-hdwallet-provider-klaytn");
+const HDWalletProvider = require("@truffle/hdwallet-provider");
 const privateKey = "0x123 ...";
 
 module.exports = {


### PR DESCRIPTION
기존 hdwallet-provider가 deprecated 되었다는 이야기도 있고 (https://github.com/trufflesuite/truffle-hdwallet-provider/issues/75#issuecomment-678812431), 무엇보다 윈도우 환경에서 설치가 안 되어서 애를 먹었는데 변경하니 잘 설치되더군요.

호환성 측면에서도 변경하는 것이 나을 것 같아요.